### PR TITLE
Implement Admin Mode: teacher-only register/unregister

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -6,13 +6,24 @@ for extracurricular activities at Mergington High School.
 """
 
 from fastapi import FastAPI, HTTPException
+from fastapi import Depends, Cookie, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import json
+import secrets
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+# Simple teacher auth store backed by a JSON file.
+teachers_file = Path(__file__).parent / "teachers.json"
+with open(teachers_file, "r", encoding="utf-8") as f:
+    teachers = json.load(f)
+
+# In-memory session registry (good enough for this exercise app).
+active_sessions = {}
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -78,6 +89,21 @@ activities = {
 }
 
 
+def get_teacher_username(teacher_session: str | None = Cookie(default=None)):
+    if not teacher_session or teacher_session not in active_sessions:
+        return None
+    return active_sessions[teacher_session]
+
+
+def teacher_required(username: str | None = Depends(get_teacher_username)):
+    if not username:
+        raise HTTPException(
+            status_code=401,
+            detail="Only logged-in teachers can register or unregister students"
+        )
+    return username
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -88,8 +114,48 @@ def get_activities():
     return activities
 
 
+@app.get("/auth/status")
+def auth_status(username: str | None = Depends(get_teacher_username)):
+    return {
+        "authenticated": bool(username),
+        "username": username
+    }
+
+
+@app.post("/auth/login")
+def teacher_login(username: str, password: str, response: Response):
+    if username not in teachers or teachers[username] != password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    session_token = secrets.token_urlsafe(32)
+    active_sessions[session_token] = username
+    response.set_cookie(
+        key="teacher_session",
+        value=session_token,
+        httponly=True,
+        samesite="lax",
+        max_age=60 * 60 * 8,
+    )
+    return {"message": "Logged in successfully", "username": username}
+
+
+@app.post("/auth/logout")
+def teacher_logout(
+    response: Response,
+    teacher_session: str | None = Cookie(default=None)
+):
+    if teacher_session and teacher_session in active_sessions:
+        del active_sessions[teacher_session]
+    response.delete_cookie("teacher_session")
+    return {"message": "Logged out successfully"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    _: str = Depends(teacher_required)
+):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -111,7 +177,11 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    _: str = Depends(teacher_required)
+):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,65 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const authStatus = document.getElementById("auth-status");
+  const userMenuBtn = document.getElementById("user-menu-btn");
+  const authMenu = document.getElementById("auth-menu");
+  const loginModal = document.getElementById("login-modal");
+  const openLoginBtn = document.getElementById("open-login-btn");
+  const closeAuthMenuBtn = document.getElementById("close-auth-menu-btn");
+  const cancelLoginBtn = document.getElementById("cancel-login-btn");
+  const loginForm = document.getElementById("login-form");
+  const logoutBtn = document.getElementById("logout-btn");
+  const authMenuState = document.getElementById("auth-menu-state");
+
+  let isTeacherLoggedIn = false;
+  let teacherUsername = null;
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateAuthUi() {
+    if (isTeacherLoggedIn) {
+      authStatus.textContent = `Teacher logged in: ${teacherUsername}`;
+      authMenuState.textContent = `Logged in as ${teacherUsername}`;
+      openLoginBtn.classList.add("hidden");
+      logoutBtn.classList.remove("hidden");
+    } else {
+      authStatus.textContent = "Students can view registrations. Teachers must log in to register/unregister.";
+      authMenuState.textContent = "Not logged in";
+      openLoginBtn.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+    }
+  }
+
+  async function refreshAuthStatus() {
+    try {
+      const response = await fetch("/auth/status");
+      const data = await response.json();
+      isTeacherLoggedIn = data.authenticated;
+      teacherUsername = data.username;
+    } catch (error) {
+      isTeacherLoggedIn = false;
+      teacherUsername = null;
+      console.error("Error checking auth status:", error);
+    }
+    updateAuthUi();
+  }
+
+  function openModal(modal) {
+    modal.classList.remove("hidden");
+  }
+
+  function closeModal(modal) {
+    modal.classList.add("hidden");
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -86,26 +145,15 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -130,31 +178,79 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  userMenuBtn.addEventListener("click", () => {
+    openModal(authMenu);
+  });
+
+  closeAuthMenuBtn.addEventListener("click", () => {
+    closeModal(authMenu);
+  });
+
+  openLoginBtn.addEventListener("click", () => {
+    closeModal(authMenu);
+    openModal(loginModal);
+  });
+
+  cancelLoginBtn.addEventListener("click", () => {
+    closeModal(loginModal);
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const username = document.getElementById("teacher-username").value;
+    const password = document.getElementById("teacher-password").value;
+
+    try {
+      const response = await fetch(
+        `/auth/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        { method: "POST" }
+      );
+      const data = await response.json();
+
+      if (response.ok) {
+        showMessage(data.message, "success");
+        loginForm.reset();
+        closeModal(loginModal);
+        await refreshAuthStatus();
+      } else {
+        showMessage(data.detail || "Login failed", "error");
+      }
+    } catch (error) {
+      showMessage("Login failed. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      const response = await fetch("/auth/logout", { method: "POST" });
+      const data = await response.json();
+      if (response.ok) {
+        showMessage(data.message, "success");
+      }
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+
+    closeModal(authMenu);
+    await refreshAuthStatus();
+  });
+
   // Initialize app
+  refreshAuthStatus();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,12 @@
   </head>
   <body>
     <header>
+      <div class="header-actions">
+        <button id="user-menu-btn" class="user-menu-btn" type="button">User</button>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <p id="auth-status" class="auth-status">Checking teacher login status...</p>
     </header>
 
     <main>
@@ -44,6 +48,36 @@
     <footer>
       <p>&copy; 2026 Mergington High School</p>
     </footer>
+
+    <div id="auth-menu" class="modal hidden" aria-hidden="true">
+      <div class="modal-content">
+        <h3>Teacher Access</h3>
+        <p id="auth-menu-state">Not logged in</p>
+        <button id="open-login-btn" type="button">Login</button>
+        <button id="logout-btn" type="button" class="hidden">Logout</button>
+        <button id="close-auth-menu-btn" type="button" class="secondary">Close</button>
+      </div>
+    </div>
+
+    <div id="login-modal" class="modal hidden" aria-hidden="true">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="teacher-username">Username:</label>
+            <input type="text" id="teacher-username" required />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password:</label>
+            <input type="password" id="teacher-password" required />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button id="cancel-login-btn" type="button" class="secondary">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,12 +16,39 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+.header-actions {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+}
+
+.user-menu-btn {
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.user-menu-btn:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.auth-status {
+  margin-top: 12px;
+  font-size: 14px;
+  opacity: 0.95;
 }
 
 header h1 {
@@ -164,6 +191,14 @@ button:hover {
   background-color: #3949ab;
 }
 
+button.secondary {
+  background-color: #6c757d;
+}
+
+button.secondary:hover {
+  background-color: #5a6268;
+}
+
 .message {
   margin-top: 20px;
   padding: 10px;
@@ -192,9 +227,55 @@ button:hover {
   display: none;
 }
 
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 420px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.modal-content h3 {
+  margin-bottom: 12px;
+  color: #1a237e;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.modal-actions button {
+  flex: 1;
+}
+
 footer {
   text-align: center;
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+@media (max-width: 600px) {
+  .header-actions {
+    position: static;
+    text-align: right;
+    margin-right: 12px;
+  }
+
+  .auth-status {
+    margin: 10px 12px 0;
+  }
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+{
+  "teacher.jones": "welcome123",
+  "coach.lee": "goTigers!"
+}


### PR DESCRIPTION
## Summary
Implements issue #5 (Admin Mode) by adding teacher authentication and restricting student registration changes to logged-in teachers.

## What changed
- Added backend teacher auth endpoints:
  - `POST /auth/login`
  - `POST /auth/logout`
  - `GET /auth/status`
- Added teacher session handling via httpOnly cookie.
- Protected mutation endpoints so only logged-in teachers can:
  - register students for activities
  - unregister students from activities
- Added teacher credentials JSON file for backend checks:
  - `src/teachers.json`
- Updated frontend with:
  - top-right user button
  - login/logout modals
  - auth status indicator
  - auth-aware messaging
- Added responsive styles for desktop and phone.

## Verification
- Unauthorized signup returns 401.
- Teacher login succeeds and then signup succeeds.
- Logout succeeds and auth requirement is enforced again.

## Notes
- Public activity viewing remains available to all users.
- This follows the issue request to store teacher credentials in a JSON file.

Closes #5